### PR TITLE
Move conversation handler definitions before main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1453,6 +1453,13 @@ async def end_support_chat(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return ConversationHandler.END
 
 # =================================================================
+# ConversationHandler assignments (moved here for correct order)
+# =================================================================
+conv_handler_quick_report = create_quick_report_conversation()
+conv_handler_full_report = create_full_report_conversation()
+conv_handler_venting = create_venting_conversation()
+
+# =================================================================
 # Main Function
 # =================================================================
 


### PR DESCRIPTION
Move `ConversationHandler` assignments to resolve `NameError` due to undefined variables in `main()`.