### PR TITLE
Fix PTBUserWarning in ConversationHandler

### DIFF
--- a/main.py
+++ b/main.py
@@ -654,7 +654,9 @@ def create_venting_conversation():
         fallbacks=[
             CommandHandler("start", cancel_venting),
             MessageHandler(filters.Regex("^❌ ביטול$"), cancel_venting)
-        ]
+        ],
+        per_user=True,
+        per_chat=True,
     )
 
 # =================================================================


### PR DESCRIPTION
Add `per_user` and `per_chat` parameters to `ConversationHandler` to resolve `PTBUserWarning` warnings.